### PR TITLE
Add fbdev support for ODROID in Makefile

### DIFF
--- a/shell/odroid/Makefile
+++ b/shell/odroid/Makefile
@@ -23,14 +23,18 @@ ASFLAGS := -march=armv7-a -mfpu=neon -mfloat-abi=hard
 
 LDFLAGS	:=	-g -Wl,-Map,$(notdir $@).map,--gc-sections -Wl,-O3 -Wl,--sort-common 
 
-
 CXXFLAGS := -g -O3  -D RELEASE -c -D TARGET_BEAGLE -D TARGET_LINUX_ARMELv7
 CXXFLAGS += -frename-registers -fno-strict-aliasing -fsingle-precision-constant 
 CXXFLAGS += -ffast-math -ftree-vectorize -fprefetch-loop-arrays 
-#-std=c++0x
-
 CXXFLAGS += $(CFLAGS) $(MFLAGS) -fno-exceptions -fno-rtti
 CXXFLAGS += -DARM_HARDFP -DGLES -DODROID -DUSES_HOMEDIR
+#-std=c++0x
+
+INCS	:= -I/usr/include -I$(RZDCY_SRC_DIR) -I$(RZDCY_SRC_DIR)/deps -I$(RZDCY_SRC_DIR)/khronos -I../linux-deps/include
+
+LIBS    := -L/usr/lib/arm-linux-gnueabihf/ -L../linux-deps/lib
+LIBS    += -lm -lrt -lEGL -lGLESv2 #-lglslcompiler -lIMGegl -lpvr2d -lsrv_um 
+LIBS    += -lpthread
 
 ifndef NO_X11
 	CXXFLAGS += -DSUPPORT_X11
@@ -61,12 +65,6 @@ endif
 ifdef USE_VMEM_FILE
         CXXFLAGS += -DUSE_VMEM_FILE
 endif
-
-INCS	:= -I/usr/include -I$(RZDCY_SRC_DIR) -I$(RZDCY_SRC_DIR)/deps -I$(RZDCY_SRC_DIR)/khronos -I../linux-deps/include
-
-LIBS    := -L/usr/lib/arm-linux-gnueabihf/ -L../linux-deps/lib
-LIBS    += -lm -lrt -lEGL -lGLESv2 #-lglslcompiler -lIMGegl -lpvr2d -lsrv_um 
-LIBS    += -lpthread
 
 ifndef NO_X11
 	LIBS += -lX11

--- a/shell/odroid/Makefile
+++ b/shell/odroid/Makefile
@@ -38,6 +38,7 @@ LIBS    += -lpthread
 
 ifndef NO_X11
 	CXXFLAGS += -DSUPPORT_X11
+	LIBS += -lX11
 endif
 
 ifdef PGO_MAKE
@@ -64,10 +65,6 @@ endif
 
 ifdef USE_VMEM_FILE
         CXXFLAGS += -DUSE_VMEM_FILE
-endif
-
-ifndef NO_X11
-	LIBS += -lX11
 endif
 
 OBJECTS=$(RZDCY_FILES:.cpp=.build_obj)

--- a/shell/odroid/Makefile
+++ b/shell/odroid/Makefile
@@ -30,7 +30,11 @@ CXXFLAGS += -ffast-math -ftree-vectorize -fprefetch-loop-arrays
 #-std=c++0x
 
 CXXFLAGS += $(CFLAGS) $(MFLAGS) -fno-exceptions -fno-rtti
-CXXFLAGS +=  -DARM_HARDFP -DGLES -DSUPPORT_X11 -DODROID -DUSES_HOMEDIR
+CXXFLAGS += -DARM_HARDFP -DGLES -DODROID -DUSES_HOMEDIR
+
+ifndef NO_X11
+	CXXFLAGS += -DSUPPORT_X11
+endif
 
 ifdef PGO_MAKE
 	CXXFLAGS += -fprofile-generate -pg
@@ -42,7 +46,6 @@ endif
 ifdef PGO_USE
 	CXXFLAGS += -fprofile-use
 endif
-
 
 ifdef LTO_TEST
 	CXXFLAGS += -flto -fwhole-program 
@@ -63,8 +66,11 @@ INCS	:= -I/usr/include -I$(RZDCY_SRC_DIR) -I$(RZDCY_SRC_DIR)/deps -I$(RZDCY_SRC_
 
 LIBS    := -L/usr/lib/arm-linux-gnueabihf/ -L../linux-deps/lib
 LIBS    += -lm -lrt -lEGL -lGLESv2 #-lglslcompiler -lIMGegl -lpvr2d -lsrv_um 
-LIBS    += -lpthread -lX11
+LIBS    += -lpthread
 
+ifndef NO_X11
+	LIBS += -lX11
+endif
 
 OBJECTS=$(RZDCY_FILES:.cpp=.build_obj)
 OBJECTS:=$(OBJECTS:.c=.build_obj)


### PR DESCRIPTION
This PR makes it possible to uncomment the NO_X11 flag to compile reicast for framebuffer on ODROIDs.

If you don't like moving INC and LIBS to the top of the Makefile, just `git cherry-pick 29f193f1a81c38c3d13e74c98d1717d01df2d9a7`.
